### PR TITLE
Typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ xray==0.6.1
 bottleneck==1.0.0
 dateutil==2.4.2
 json==2.0.9
-palettable=2.1.1
+palettable==2.1.1


### PR DESCRIPTION
pip install -r requirements complained about this =, and suggested using ==. Looking at the other requirements, I believe this PR fixes it.
