### PR TITLE
Fix wrong operator on requirement.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ basemap==1.0.7
 xray==0.6.1
 bottleneck==1.0.0
 json==2.0.9
-palettable=2.1.1
+palettable==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ matplotlib==1.5.0
 basemap==1.0.7
 xray==0.6.1
 bottleneck==1.0.0
-json==2.0.9
 palettable==2.1.1


### PR DESCRIPTION
pip was complaining about a wrong operator being used for palettable.
