### PR TITLE
Update requirements.txt removing the package itself

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-paleopy
 numpy==1.10.1
 scipy==0.16.0
 pandas==0.17.0


### PR DESCRIPTION
Hi Nico! I think the package paleopy must not be listed in the requirements.txt, as the requirements.txt specifies the dependencies for paleopy.

This pull request simply removes that line.
